### PR TITLE
feat: view account page

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "@emotion/styled": "^11",
     "@hookform/resolvers": "^2.8.8",
     "@prisma/client": "^3.9.2",
-    "@radix-ui/react-icons": "^1.0.3",
     "axios": "^0.26.0",
     "framer-motion": "^6",
+    "luxon": "^2.3.0",
     "next": "12.1.0",
     "nextjs-progressbar": "^0.0.13",
     "prisma": "^3.9.2",
@@ -31,6 +31,7 @@
     "@chakra-ui/cli": "^1.8.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
+    "@types/luxon": "^2.0.9",
     "@types/node": "17.0.18",
     "@types/react": "17.0.39",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -56,7 +57,6 @@
       {
         "path": "@semantic-release/git",
         "assets": [
-          "package.json",
           "package-lock.json",
           "yarn.lock",
           "CHANGELOG.md"

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -42,7 +42,12 @@ export const Layout: FC<LayoutProps> = ({ children, pageTitle }): JSX.Element =>
           {children}
         </Container>
       </Box>
-      <Box backgroundColor="gray.900" borderTopColor="gray.700" borderTopWidth="1px" minHeight="xs">
+      <Box
+        backgroundColor="gray.800"
+        borderTopColor="whiteAlpha.300"
+        borderTopWidth="1px"
+        minHeight="xs"
+      >
         <Container marginY={{ base: "4", md: "8", xl: "12" }} maxWidth="container.lg">
           <Logo />
           <Divider marginY="2" />

--- a/src/components/logo/index.tsx
+++ b/src/components/logo/index.tsx
@@ -1,10 +1,10 @@
 import { Heading, HStack, Icon } from "@chakra-ui/react";
-import { CrumpledPaperIcon } from "@radix-ui/react-icons";
+import { IoWaterOutline } from "react-icons/io5";
 
 export function Logo(): JSX.Element {
   return (
     <HStack>
-      <Icon as={CrumpledPaperIcon} height="10" width="10" />
+      <Icon as={IoWaterOutline} height="10" width="10" />
       <Heading>Sword</Heading>
     </HStack>
   );

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -1,7 +1,7 @@
 import { Box, chakra, Flex, HStack, IconButton, useDisclosure, VStack } from "@chakra-ui/react";
-import { Cross1Icon, HamburgerMenuIcon } from "@radix-ui/react-icons";
 import NextLink from "next/link";
 import React from "react";
+import { IoCloseOutline, IoMenuOutline } from "react-icons/io5";
 
 import { Logo } from "../logo";
 import { NAV_ITEMS } from "./items";
@@ -13,13 +13,14 @@ export function Navigation(): JSX.Element {
   return (
     <React.Fragment>
       <chakra.header
-        background="gray.900"
+        backgroundColor="gray.800"
+        borderBottomColor="whiteAlpha.300"
+        borderBottomWidth="1px"
         display="flex"
         height="24"
         paddingX={{ base: 2, md: 4, xl: 6 }}
         position="sticky"
         top={0}
-        shadow="xl"
         width="full"
         zIndex="sticky"
       >
@@ -48,7 +49,7 @@ export function Navigation(): JSX.Element {
                 color="inherit"
                 display={{ base: "flex", md: "none" }}
                 fontSize="20px"
-                icon={<HamburgerMenuIcon />}
+                icon={<IoMenuOutline />}
                 onClick={mobileNav.onOpen}
                 variant="ghost"
               />
@@ -73,7 +74,7 @@ export function Navigation(): JSX.Element {
                   aria-label="Open menu"
                   color="inherit"
                   fontSize="20px"
-                  icon={<Cross1Icon />}
+                  icon={<IoCloseOutline />}
                   onClick={mobileNav.onClose}
                   variant="ghost"
                   width="full"

--- a/src/components/navigation/items.ts
+++ b/src/components/navigation/items.ts
@@ -1,26 +1,26 @@
-import { EnterIcon, HomeIcon, PlusIcon } from "@radix-ui/react-icons";
-import { IconProps } from "@radix-ui/react-icons/dist/types";
+import { IconType } from "react-icons";
+import { IoHomeOutline, IoLogInOutline, IoPersonAddOutline } from "react-icons/io5";
 
 export interface NavItem {
   label: string;
-  Icon?: React.ForwardRefExoticComponent<IconProps & React.RefAttributes<SVGSVGElement>>;
+  Icon?: IconType;
   href: string;
 }
 
 export const NAV_ITEMS: Array<NavItem> = [
   {
     label: "Home",
-    Icon: HomeIcon,
+    Icon: IoHomeOutline,
     href: "/",
   },
   {
     label: "Login",
-    Icon: EnterIcon,
+    Icon: IoLogInOutline,
     href: "/login",
   },
   {
     label: "Register",
-    Icon: PlusIcon,
+    Icon: IoPersonAddOutline,
     href: "/register",
   },
 ];

--- a/src/pages/account/[name].tsx
+++ b/src/pages/account/[name].tsx
@@ -1,0 +1,171 @@
+import {
+  Avatar,
+  Divider,
+  Heading,
+  Icon,
+  SimpleGrid,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { players } from "@prisma/client";
+import { DateTime } from "luxon";
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import {
+  IoIdCardOutline,
+  IoPeopleOutline,
+  IoPersonOutline,
+  IoSettingsOutline,
+} from "react-icons/io5";
+
+import { Layout } from "../../components/layout";
+import { setupApiClient } from "../../services/axios";
+
+type SingleAccount = {
+  id: number;
+  name: string;
+  email: string;
+  type: number;
+  premium_ends_at: number;
+  creation: number;
+  players?: players[];
+} | null;
+
+const Account: NextPage = () => {
+  const [account, setAccount] = useState<SingleAccount>();
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const { name } = router.query;
+      if (!name) return;
+
+      const api = setupApiClient();
+
+      await api
+        .get<{ account: SingleAccount }>(
+          `/account/read?type=one&name=${name}&shouldBringRelations=true`
+        )
+        .then(({ data }) => {
+          setAccount(data.account);
+        })
+        .catch(({ response }) => console.log(response.data));
+    })();
+  }, [router]);
+
+  if (!account) {
+    return (
+      <Layout pageTitle="Loading - Account">
+        <Heading>Loading</Heading>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout pageTitle={`${account.name} - Account`}>
+      {/** BEGIN Avatar, Name and Email */}
+      <SimpleGrid
+        columns={{
+          base: 1,
+          md: 2,
+        }}
+        marginX="auto"
+        gap="5"
+        width="fit-content"
+      >
+        <Avatar
+          backgroundColor="primary.500"
+          marginX={{
+            base: "auto",
+            md: 0,
+          }}
+          size="2xl"
+        />
+        <VStack marginY="auto" spacing="1">
+          <Heading>{account.name}</Heading>
+          <Text>{account.email}</Text>
+        </VStack>
+      </SimpleGrid>
+      {/** END Avatar, Name and Email */}
+
+      {/** BEGIN Account Info Tabs */}
+      <Tabs marginY="5" variant="solid-rounded">
+        <TabList gap="2.5" justifyContent="center" flexWrap="wrap">
+          <Tab>
+            <Icon as={IoIdCardOutline} marginRight="1" />
+            Account
+          </Tab>
+          <Tab>
+            <Icon as={IoPersonOutline} marginRight="1" />
+            Characters
+          </Tab>
+          <Tab>
+            <Icon as={IoPeopleOutline} marginRight="1" /> Friends
+          </Tab>
+          <Tab>
+            <Icon as={IoSettingsOutline} marginRight="1" /> Settings
+          </Tab>
+        </TabList>
+        <Divider marginY="2" />
+        <TabPanels>
+          <TabPanel>
+            <VStack alignItems="flex-start" spacing="1.5">
+              <Text display="flex">
+                <Text fontWeight="semibold" marginRight="1.5">
+                  Group:
+                </Text>
+                {account.type}
+              </Text>
+              <Text display="flex">
+                <Text fontWeight="semibold" marginRight="1.5">
+                  Premium:
+                </Text>
+                {account.premium_ends_at !== 0
+                  ? `Ends in ${DateTime.fromSeconds(account.premium_ends_at).toLocaleString({
+                      day: "2-digit",
+                      month: "long",
+                      year: "numeric",
+                    })}`
+                  : "No"}
+              </Text>
+              <Text display="flex">
+                <Text fontWeight="semibold" marginRight="1.5">
+                  Total characters:
+                </Text>
+                {account.players && account.players.length > 0 ? account.players.length : 0}
+              </Text>
+              <Text display="flex">
+                <Text fontWeight="semibold" marginRight="1.5">
+                  Created at:
+                </Text>
+                {DateTime.fromSeconds(account.creation).toLocaleString({
+                  day: "2-digit",
+                  month: "long",
+                  year: "numeric",
+                })}
+              </Text>
+            </VStack>
+          </TabPanel>
+          <TabPanel>
+            <p>Characters</p>
+          </TabPanel>
+          <TabPanel>
+            <p>Friends</p>
+          </TabPanel>
+          <TabPanel>
+            <p>Settings</p>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+      {/** END Account Info Tabs */}
+    </Layout>
+  );
+};
+
+export default Account;

--- a/src/pages/api/account/read.ts
+++ b/src/pages/api/account/read.ts
@@ -1,0 +1,82 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import { accounts } from "@prisma/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { prisma } from "../../../services/prisma";
+
+type QueryData = {
+  type: "all" | "one" | "filtered";
+  shouldBringRelations?: "true" | "false";
+  name?: string;
+  email?: string;
+  id?: number;
+};
+
+type Data = {
+  account?: Partial<accounts>;
+  accounts?: Partial<accounts>[];
+  message?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+): Promise<void> {
+  if (req.method === "GET") {
+    const data = req.query as unknown as QueryData;
+
+    if (data.type === "all") {
+      const accounts = await prisma.accounts.findMany({
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          creation: true,
+          premium_ends_at: true,
+          type: true,
+          players: data.shouldBringRelations === "true",
+        },
+      });
+
+      return res.status(200).json({ accounts });
+    } else if (data.type === "one") {
+      const account = await prisma.accounts.findFirst({
+        where: {
+          OR: [
+            { id: { equals: data.id } },
+            { name: { equals: data.name } },
+            { email: { equals: data.email } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          creation: true,
+          premium_ends_at: true,
+          type: true,
+          players: data.shouldBringRelations === "true",
+        },
+      });
+
+      if (!account) {
+        return res.status(400).json({
+          message: "Couldn't find the specified account",
+        });
+      }
+
+      return res.status(200).json({ account });
+    } else if (data.type === "filtered") {
+      return res.status(200).json({
+        message: "The 'filtered' search type is in development",
+      });
+    }
+    return res.status(400).json({
+      message: "Malformed request, verify your filters and/or the requested search type",
+    });
+  } else {
+    return res.status(405).json({
+      message: `You can't ${req.method} this route.`,
+    });
+  }
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,8 +1,8 @@
 import { Button, Heading, Icon, VStack } from "@chakra-ui/react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { EnterIcon } from "@radix-ui/react-icons";
 import type { NextPage } from "next";
 import { useForm } from "react-hook-form";
+import { IoLogInOutline } from "react-icons/io5";
 import * as yup from "yup";
 
 import { Input } from "../components/input";
@@ -45,7 +45,7 @@ const Login: NextPage = () => {
           type="password"
           {...register("password")}
         />
-        <Button leftIcon={<Icon as={EnterIcon} height={5} width={5} />}>Login</Button>
+        <Button leftIcon={<Icon as={IoLogInOutline} height={5} width={5} />}>Login</Button>
       </VStack>
     </Layout>
   );

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -1,10 +1,10 @@
 import { Button, Heading, Icon, SimpleGrid, useToast, VStack } from "@chakra-ui/react";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { CheckIcon, PlusIcon } from "@radix-ui/react-icons";
 import { AxiosError } from "axios";
 import type { NextPage } from "next";
 import { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
+import { IoCheckmarkOutline, IoPersonAddOutline } from "react-icons/io5";
 import * as yup from "yup";
 
 import { Input } from "../components/input";
@@ -134,9 +134,9 @@ const Register: NextPage = () => {
           isLoading={formState.isSubmitting}
           leftIcon={
             formState.isSubmitSuccessful && !creationError ? (
-              <Icon as={CheckIcon} height={5} width={5} />
+              <Icon as={IoCheckmarkOutline} height={5} width={5} />
             ) : (
-              <Icon as={PlusIcon} height={5} width={5} />
+              <Icon as={IoPersonAddOutline} height={5} width={5} />
             )
           }
           type="submit"

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,11 +906,6 @@
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz#e5c345cdedb7be83d11c1e0c5ab61d866b411256"
   integrity sha512-qM+uJbkelB21bnK44gYE049YTHIjHysOuj0mj5U2gDGyNLfmiazlggzFPCgEjgme4U5YB2tYs6Z5Hq08Kl8pjA==
 
-"@radix-ui/react-icons@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.0.3.tgz#4ef61f1234f44991f7a19e108f77ca37032b4be2"
-  integrity sha512-YbPAUZwTsvF/2H7IU35txaLUB+JNSV8GIhnswlqiFODP/P32t5op5keYUvQWsSj9TA0VLF367J24buUjIprn0w==
-
 "@reach/alert@0.13.2":
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.13.2.tgz#71c4a848d51341f1d6d9eaae060975391c224870"
@@ -1025,6 +1020,11 @@
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
+"@types/luxon@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.0.9.tgz#782a0edfa6d699191292c13168bd496cd66b87c6"
+  integrity sha512-ZuzIc7aN+i2ZDMWIiSmMdubR9EMMSTdEzF6R+FckP4p6xdnOYKqknTo/k+xXQvciSXlNGIwA4OPU5X7JIFzYdA==
 
 "@types/node@17.0.18":
   version "17.0.18"
@@ -2760,6 +2760,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.3.0.tgz#bf16a7e642513c2a20a6230a6a41b0ab446d0045"
+  integrity sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==
 
 make-dir@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
## What was implemented in this:

Account reading through `/api/account/read`. Uses (at the moment of this PR) 5 query params.

- Page `/account/[name]` added with basic account info and scaffolding for next features
- Changed icon pack used, from `Radix UI Icons` to `Ionicons 5`
- Navbar and Footer background colors changed to `gray.800`, that is, to the same as the page background color

### Available Query Params
- (mandatory) `type`: can be `all` or `one` or `filtered`. The last of them wasn't implemented in this PR.
- (optional) `name`: the account name to search for (treated as unique)
- (optional) `email`: the email used to search for a account (treated as unique)
- (optional) `id`: the id of the account to search for (well... obviously, unique)
- (optional) `shouldBringRelations`: if set to `true` the SQL relations will be returned too (things like characters, VIP list, etc...)

## What wasn't implemented in this

- The `filtered` type