### PR TITLE
feat: added account deletion

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,18 @@
 import { ChakraProvider } from "@chakra-ui/provider";
+import { cookieStorageManager, localStorageManager } from "@chakra-ui/react";
 import type { AppProps } from "next/app";
 import NextNProgress from "nextjs-progressbar";
 
 import { theme } from "../theme";
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+  const colorModeManager =
+    typeof pageProps.cookies === "string"
+      ? cookieStorageManager(pageProps.cookies)
+      : localStorageManager;
+
   return (
-    <ChakraProvider theme={theme}>
+    <ChakraProvider colorModeManager={colorModeManager} theme={theme}>
       <NextNProgress color="#4169E1" startPosition={0.5} stopDelayMs={100} height={5} />
       <Component {...pageProps} />
     </ChakraProvider>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,3 @@
-import { ColorModeScript } from "@chakra-ui/color-mode";
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
@@ -14,7 +13,6 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
-          <ColorModeScript />
           <Main />
           <NextScript />
         </body>

--- a/src/pages/api/account/delete.ts
+++ b/src/pages/api/account/delete.ts
@@ -1,0 +1,60 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import { accounts } from "@prisma/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { prisma } from "../../../services/prisma";
+
+type Data = {
+  account?: Partial<accounts>;
+  message?: string;
+};
+
+type BodyData = {
+  idToDelete: number;
+  confirmation: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+): Promise<void> {
+  if (req.method === "DELETE") {
+    const data: BodyData = req.body;
+
+    const account = await prisma.accounts.findFirst({
+      where: {
+        id: { equals: data.idToDelete },
+      },
+    });
+
+    if (!account) {
+      return res.status(400).json({
+        message: "Couldn't find the specified account.",
+      });
+    }
+
+    if (data.confirmation !== account.name) {
+      return res.status(400).json({
+        message: "Couldn't validate this deletion",
+      });
+    }
+
+    const deletedAccount = await prisma.accounts.delete({
+      where: {
+        id: data.idToDelete,
+      },
+      select: {
+        name: true,
+        creation: true,
+      },
+    });
+
+    return res.status(200).json({
+      account: deletedAccount,
+    });
+  } else {
+    return res.status(405).json({
+      message: `You can't ${req.method} this route.`,
+    });
+  }
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,139 +1,121 @@
-import { extendTheme } from "@chakra-ui/react";
+import { extendTheme, withDefaultColorScheme, withDefaultSize } from "@chakra-ui/react";
 
-export const theme = extendTheme({
-  colors: {
-    primary: {
-      100: "#D9E6FD",
-      200: "#B4CBFC",
-      300: "#8DACF6",
-      400: "#6E91EC",
-      500: "#4169E1",
-      600: "#2F50C1",
-      700: "#203AA2",
-      800: "#142782",
-      900: "#0C1A6C",
+export const theme = extendTheme(
+  {
+    colors: {
+      primary: {
+        100: "#D9E6FD",
+        200: "#B4CBFC",
+        300: "#8DACF6",
+        400: "#6E91EC",
+        500: "#4169E1",
+        600: "#2F50C1",
+        700: "#203AA2",
+        800: "#142782",
+        900: "#0C1A6C",
+      },
     },
-  },
-  components: {
-    Alert: {
-      baseStyle: {
-        container: {
+    components: {
+      Alert: {
+        baseStyle: {
+          container: {
+            borderRadius: "sm",
+          },
+        },
+      },
+      Button: {
+        baseStyle: {
           borderRadius: "sm",
         },
-      },
-    },
-    Button: {
-      baseStyle: {
-        borderRadius: "sm",
-      },
-      variants: {
-        solid: {
-          _hover: {
-            backgroundColor: "primary.400",
-            _disabled: {
-              backgroundColor: "primary.500",
-            },
-          },
-          _focus: {
-            backgroundColor: "primary.600",
-            _focus: {
-              backgroundColor: "primary.600",
-            },
-            _hover: {
-              backgroundColor: "primary.600",
-            },
-            _disabled: {
-              backgroundColor: "primary.500",
-            },
-          },
-          backgroundColor: "primary.500",
-          color: "white",
+        defaultProps: {
+          size: "lg",
         },
       },
-      defaultProps: {
-        size: "lg",
-        variant: "solid",
-      },
-    },
-    Input: {
-      variants: {
-        filled: {
-          field: {
-            _hover: {
+      Input: {
+        variants: {
+          filled: {
+            field: {
+              _hover: {
+                backgroundColor: "gray.900",
+              },
+              _focus: {
+                backgroundColor: "gray.900",
+                borderColor: "primary.500",
+              },
               backgroundColor: "gray.900",
+              borderRadius: "sm",
+              color: "gray.100",
             },
-            _focus: {
-              backgroundColor: "gray.900",
-              borderColor: "primary.500",
-            },
-            backgroundColor: "gray.900",
-            color: "gray.100",
-            rounded: "sm",
           },
         },
-      },
-      defaultProps: {
-        size: "lg",
-        variant: "filled",
-      },
-    },
-    Modal: {
-      baseStyle: {
-        closeButton: {
-          borderRadius: "sm",
+        defaultProps: {
+          size: "lg",
+          variant: "filled",
         },
       },
-      variants: {
-        main: {
+      Modal: {
+        baseStyle: {
+          closeButton: {
+            borderRadius: "sm",
+          },
           dialog: {
-            backgroundColor: "gray.900",
+            backgroundColor: "gray.800",
             borderRadius: "sm",
+            padding: 2.5,
+            paddingX: 5,
           },
-          close: {
-            borderRadius: "sm",
+          body: {
+            marginTop: 3.5,
+            padding: 0,
+          },
+          footer: {
+            padding: 0,
+          },
+          header: {
+            fontSize: "2xl",
+            padding: 0,
           },
         },
       },
-      defaultProps: {
-        variant: "main",
-      },
-    },
-    Select: {
-      variants: {
-        filled: {
-          field: {
-            _hover: {
+      Select: {
+        variants: {
+          filled: {
+            field: {
+              _hover: {
+                backgroundColor: "gray.900",
+              },
+              _focus: {
+                backgroundColor: "gray.900",
+                borderColor: "primary.500",
+              },
               backgroundColor: "gray.900",
+              color: "gray.100",
+              rounded: "sm",
             },
-            _focus: {
-              backgroundColor: "gray.900",
-              borderColor: "primary.500",
-            },
-            backgroundColor: "gray.900",
-            color: "gray.100",
-            rounded: "sm",
           },
         },
+        defaultProps: {
+          size: "lg",
+          variant: "filled",
+        },
       },
-      defaultProps: {
-        size: "lg",
-        variant: "filled",
+    },
+    config: {
+      initialColorMode: "dark",
+      useSystemColorMode: false,
+    },
+    fonts: {
+      heading: "Poppins",
+      body: "Poppins",
+    },
+    styles: {
+      global: {
+        body: {
+          backgroundColor: "gray.800",
+        },
       },
     },
   },
-  config: {
-    initialColorMode: "dark",
-    useSystemColorMode: false,
-  },
-  fonts: {
-    heading: "Poppins",
-    body: "Poppins",
-  },
-  styles: {
-    global: {
-      body: {
-        backgroundColor: "gray.800",
-      },
-    },
-  },
-});
+  withDefaultColorScheme({ colorScheme: "primary" }),
+  withDefaultSize({ size: "lg" })
+);


### PR DESCRIPTION
## What was implemented in this:

Account deleting through `/api/account/delete`. Needs account ID to delete and an confirmation of deletion, which is the account name sent via body as:
```json
{
  "idToDelete": 1,
  "confirmation": "ivo"
}
```

- Added Account delete modal in settings tab on `/account/[name]`

## What wasn't implemented in this

- Validation of actual login, since we don't have this yet